### PR TITLE
Opacity

### DIFF
--- a/Configs/alacritty.yml
+++ b/Configs/alacritty.yml
@@ -1,4 +1,4 @@
-background_opacity: 1.0
+window.opacity: 1.0
 colors:
   primary:
     background: '0x292d3e'


### PR DESCRIPTION
background_opacity it's deprecated, you should use "window.opacity" instead